### PR TITLE
Making quickfind readable in Dark theme

### DIFF
--- a/VsDarkUI/$(BaseDir)/Settings/Themes/VsDark.fdi
+++ b/VsDarkUI/$(BaseDir)/Settings/Themes/VsDark.fdi
@@ -123,7 +123,7 @@ Panel.BackColor=#252526
 
 ### MAIN INTERFACE
 
-QuickFind.ForeColor=#1B293E
+QuickFind.ForeColor=#F1F1F1
 QuickFind.BackColor=#2D2D30
 
 SplitterControl.BackColor=#2D2D30


### PR DESCRIPTION
Changed from a very dark blue to the same semi-dark white used everywhere else. This makes the checkboxes on the Quick Find toolbar actually readable when using the VsDark theme.
